### PR TITLE
bug: resend otp should not required account to be verified

### DIFF
--- a/src/Modules/Auth/Auth/Application/Public/UseCases/Commands/ResendOtp/PublicResendOtpHandler.cs
+++ b/src/Modules/Auth/Auth/Application/Public/UseCases/Commands/ResendOtp/PublicResendOtpHandler.cs
@@ -42,7 +42,6 @@ public class PublicResendOtpHandler(
         UserEntity? user = await userRepository.GetUserWithRolesByEmailOrThrow(email, cancellationToken);
 
         userRepository.IsUserAccountActive(user!);
-        userRepository.IsUserAccountVerified(user!);
 
         // Invalidate existing OTPs for this purpose
         await otpRepository.InvalidateExistingOtpsAsync(user!.Id, purpose, cancellationToken);


### PR DESCRIPTION
- [x] remove the `userRepository.IsUserAccountVerified(user!);` check 