### PR TITLE
bug: fix Swagger/OpenAPI generating wrong schema for avatarFile IFormFile

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,45 @@
+# Build outputs
+**/bin/
+**/obj/
+**/out/
+**/publish/
+
+# IDE files
+**/.vs/
+**/.vscode/
+**/.idea/
+**/*.user
+**/*.suo
+
+# Git
+.git/
+.gitignore
+.gitattributes
+
+# Docker
+**/Dockerfile*
+**/docker-compose*
+**/.dockerignore
+
+# Documentation
+**/*.md
+**/docs/
+
+# Tests
+**/TestResults/
+
+# Environment files (should be handled separately)
+**/.env
+**/.env.*
+
+# OS files
+.DS_Store
+Thumbs.db
+
+# Logs
+**/logs/
+**/*.log
+
+# NuGet packages (will be restored during build)
+**/packages/
+**/*.nupkg

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,3 @@
-# syntax=docker/dockerfile:1
 # Build stage
 FROM mcr.microsoft.com/dotnet/sdk:9.0 AS build
 WORKDIR /src
@@ -13,14 +12,17 @@ COPY src/Modules/Core/Core/*.csproj ./src/Modules/Core/Core/
 COPY src/Modules/Auth/Auth/*.csproj ./src/Modules/Auth/Auth/
 
 # Restore dependencies (cached layer - only rebuilds if dependencies change)
+# Use BuildKit cache mount for faster restores
 RUN --mount=type=cache,target=/root/.nuget/packages \
     dotnet restore
 
 # Copy source code (this layer changes frequently)
 COPY src/ ./src/
 
-# Build and publish
+# Build and publish with BuildKit cache mounts
 RUN --mount=type=cache,target=/root/.nuget/packages \
+    --mount=type=cache,target=/src/obj \
+    --mount=type=cache,target=/src/bin \
     dotnet publish src/Api/Api.csproj -c Release -o /app/publish
 
 # Runtime stage (smallest possible image)

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,4 @@
+# syntax=docker/dockerfile:1
 # Build stage
 FROM mcr.microsoft.com/dotnet/sdk:9.0 AS build
 WORKDIR /src
@@ -12,13 +13,15 @@ COPY src/Modules/Core/Core/*.csproj ./src/Modules/Core/Core/
 COPY src/Modules/Auth/Auth/*.csproj ./src/Modules/Auth/Auth/
 
 # Restore dependencies (cached layer - only rebuilds if dependencies change)
-RUN dotnet restore
+RUN --mount=type=cache,target=/root/.nuget/packages \
+    dotnet restore
 
 # Copy source code (this layer changes frequently)
 COPY src/ ./src/
 
 # Build and publish
-RUN dotnet publish src/Api/Api.csproj -c Release -o /app/publish
+RUN --mount=type=cache,target=/root/.nuget/packages \
+    dotnet publish src/Api/Api.csproj -c Release -o /app/publish
 
 # Runtime stage (smallest possible image)
 FROM mcr.microsoft.com/dotnet/aspnet:9.0-alpine AS runtime

--- a/src/Modules/Auth/Auth/Application/Admin/UseCases/Commands/UpdateAvatar/V1/AdminUpdateAvatarEndpointV1.cs
+++ b/src/Modules/Auth/Auth/Application/Admin/UseCases/Commands/UpdateAvatar/V1/AdminUpdateAvatarEndpointV1.cs
@@ -10,17 +10,8 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Routing;
 using System.Security.Claims;
 using _116.Auth.Application.Shared.Constants;
-using Microsoft.AspNetCore.Mvc;
 
 namespace _116.Auth.Application.Admin.UseCases.Commands.UpdateAvatar.V1;
-
-/// <summary>
-/// Request model for updating admin user avatar.
-/// </summary>
-/// <param name="AvatarFile">The avatar image file to upload.</param>
-public record AdminUpdateAvatarRequest(
-    IFormFile AvatarFile
-);
 
 /// <summary>
 /// Response model for updating admin user avatar.
@@ -49,7 +40,7 @@ public class AdminUpdateAvatarEndpointV1 : ICarterModule
             .WithTags($"{AuthConstants.Admin}::{AuthRouteConstants.Profile}");
 
         group.MapPatch(AuthRouteConstants.Avatar, async (
-                [FromForm] AdminUpdateAvatarRequest request,
+                IFormFile avatarFile,
                 ClaimsPrincipal user,
                 IUserRepository userRepository,
                 IDispatcher dispatcher
@@ -59,7 +50,7 @@ public class AdminUpdateAvatarEndpointV1 : ICarterModule
                 Guid userId = userRepository.GetUserIdFromClaims(user);
 
                 // Send the command with the uploaded file (validation happens in validator)
-                var command = new AdminUpdateAvatarCommand(userId, request.AvatarFile);
+                var command = new AdminUpdateAvatarCommand(userId, avatarFile);
                 AdminUpdateAvatarResult result = await dispatcher.Send(command);
 
                 // Return response
@@ -71,7 +62,6 @@ public class AdminUpdateAvatarEndpointV1 : ICarterModule
             .WithDescription(AdminUpdateAvatarMetaField.UpdateAvatar.Description)
             .RequireAuthorization(UserRolePolicies.RequireAdminOrSuperAdmin)
             .DisableAntiforgery()
-            .Accepts<AdminUpdateAvatarRequest>("multipart/form-data")
             .ProducesValidationProblem()
             .Produces<AdminUpdateAvatarResponse>()
             .ProducesProblem(StatusCodes.Status400BadRequest)

--- a/src/Modules/Auth/Auth/Application/Public/UseCases/Commands/UpdateAvatar/V1/PublicUpdateAvatarEndpointV1.cs
+++ b/src/Modules/Auth/Auth/Application/Public/UseCases/Commands/UpdateAvatar/V1/PublicUpdateAvatarEndpointV1.cs
@@ -10,17 +10,8 @@ using System.Security.Claims;
 using _116.Auth.Application.Shared.Constants;
 using _116.Auth.Domain.Constants;
 using _116.Shared.Application.Extensions;
-using Microsoft.AspNetCore.Mvc;
 
 namespace _116.Auth.Application.Public.UseCases.Commands.UpdateAvatar.V1;
-
-/// <summary>
-/// Request model for updating user avatar.
-/// </summary>
-/// <param name="AvatarFile">The avatar image file to upload.</param>
-public record PublicUpdateAvatarRequest(
-    IFormFile AvatarFile
-);
 
 /// <summary>
 /// Response model for updating user avatar.
@@ -49,7 +40,7 @@ public class PublicUpdateAvatarEndpointV1 : ICarterModule
             .WithTags($"{AuthConstants.Public}::{AuthRouteConstants.Profile}");
 
         group.MapPatch(AuthRouteConstants.Avatar, async (
-                [FromForm] PublicUpdateAvatarRequest request,
+                IFormFile avatarFile,
                 ClaimsPrincipal user,
                 IUserRepository userRepository,
                 IDispatcher dispatcher
@@ -59,7 +50,7 @@ public class PublicUpdateAvatarEndpointV1 : ICarterModule
                 Guid userId = userRepository.GetUserIdFromClaims(user);
 
                 // Send the command with the uploaded file (validation happens in validator)
-                var command = new PublicUpdateAvatarCommand(userId, request.AvatarFile);
+                var command = new PublicUpdateAvatarCommand(userId, avatarFile);
                 PublicUpdateAvatarResult result = await dispatcher.Send(command);
 
                 // Return response
@@ -71,7 +62,6 @@ public class PublicUpdateAvatarEndpointV1 : ICarterModule
             .WithDescription(PublicUpdateAvatarMetaField.UpdateAvatar.Description)
             .RequireAuthorization(UserRolePolicies.RequireVisitorOnly)
             .DisableAntiforgery()
-            .Accepts<PublicUpdateAvatarRequest>("multipart/form-data")
             .ProducesValidationProblem()
             .Produces<PublicUpdateAvatarResponse>()
             .ProducesProblem(StatusCodes.Status400BadRequest)

--- a/src/Modules/Auth/Auth/Application/Shared/Validators/UserValidationRules.cs
+++ b/src/Modules/Auth/Auth/Application/Shared/Validators/UserValidationRules.cs
@@ -433,7 +433,23 @@ public static partial class UserValidationRules
     /// <returns>True if MIME type is valid, false otherwise.</returns>
     private static bool BeValidImageType(IFormFile? file)
     {
-        return file != null && FileConstants.AllowedAvatarMimeTypes.Contains(file.ContentType.ToLowerInvariant());
+        if (file == null) return false;
+
+        // Extract content type without parameters (e.g., "image/jpeg" from "image/jpeg; boundary=...")
+        string contentType = file.ContentType?.Split(';')[0].Trim().ToLowerInvariant() ?? string.Empty;
+
+        // Accept if content type is in the allowed list
+        if (FileConstants.AllowedAvatarMimeTypes.Contains(contentType))
+        {
+            return true;
+        }
+
+        // For generic/missing content types (common with mobile uploads), validate by extension
+        bool isGenericContentType = string.IsNullOrEmpty(contentType) ||
+                                     contentType == "application/octet-stream" ||
+                                     contentType == "multipart/form-data";
+
+        return isGenericContentType && BeValidFileExtension(file);
     }
 
     /// <summary>

--- a/src/Modules/Core/Core/Infrastructure/Services/CloudinaryService.cs
+++ b/src/Modules/Core/Core/Infrastructure/Services/CloudinaryService.cs
@@ -109,16 +109,7 @@ public class CloudinaryService : ICloudinaryService
             throw CoreErrors.FileTooLarge(file.Length, FileConstants.MaxAvatarFileSizeBytes, maxSizeMb);
         }
 
-        // Check MIME type
-        if (!FileConstants.AllowedAvatarMimeTypes.Contains(file.ContentType.ToLowerInvariant()))
-        {
-            throw CoreErrors.InvalidFileType(
-                file.ContentType,
-                string.Join(", ", FileConstants.AllowedAvatarMimeTypes)
-            );
-        }
-
-        // Additional check: file extension
+        // Check file extension first (more reliable than MIME type for mobile uploads)
         string extension = Path.GetExtension(file.FileName).ToLowerInvariant();
         if (!FileConstants.AllowedAvatarExtensions.Contains(extension))
         {
@@ -126,6 +117,20 @@ public class CloudinaryService : ICloudinaryService
                 extension,
                 string.Join(", ", FileConstants.AllowedAvatarExtensions)
             );
+        }
+
+        // Extract content type without parameters (e.g., "image/jpeg" from "image/jpeg; boundary=...")
+        string contentType = (file.ContentType?.Split(';')[0] ?? string.Empty).Trim().ToLowerInvariant();
+
+        // Allow if content type is in allowed list OR if it's a generic type (mobile uploads)
+        bool isValidContentType = FileConstants.AllowedAvatarMimeTypes.Contains(contentType) ||
+                                   string.IsNullOrEmpty(contentType) ||
+                                   contentType == "application/octet-stream" ||
+                                   contentType == "multipart/form-data";
+
+        if (!isValidContentType)
+        {
+            throw CoreErrors.InvalidFileType(contentType, string.Join(", ", FileConstants.AllowedAvatarMimeTypes));
         }
     }
 }


### PR DESCRIPTION
- [x] [build: create .dockerignore to reduce the image size](https://github.com/coolbeatz71/116-backend/commit/339ef628efcc79a0e26a11d589f200f1ce5c3d70)
- [x] [build: use BuildKit cache mount for faster restores and build](https://github.com/coolbeatz71/116-backend/commit/bdbb1b291641c1b7ffdcaea2d10fa15ab8ca46e7)
- [x] [bug: fix Swagger/OpenAPI generating wrong schema for avatarFile IFormFile](https://github.com/coolbeatz71/116-backend/commit/f410f48ac2d81d6256d7b688af569410c9cf2331)
- [x] [bug: fix avatarFile validation rules: optimize for mobile file uploads](https://github.com/coolbeatz71/116-backend/commit/22305975e481121569107d039941dec91981aaad)