### PR TITLE
feat: implement set password for Google/Facebook auth provider

### DIFF
--- a/src/Modules/Auth/Auth/Application/Public/UseCases/Commands/ResetPassword/PublicResetPasswordCommand.cs
+++ b/src/Modules/Auth/Auth/Application/Public/UseCases/Commands/ResetPassword/PublicResetPasswordCommand.cs
@@ -26,6 +26,4 @@ public record PublicResetPasswordCommand(
 /// Simple result indicating successful password reset operation.
 /// Upon success, the user can log in with their new password.
 /// </remarks>
-public record PublicResetPasswordResult(
-    bool IsSuccess
-);
+public record PublicResetPasswordResult(bool IsSuccess);

--- a/src/Modules/Auth/Auth/Application/Public/UseCases/Commands/SetPassword/PublicSetPasswordCommand.cs
+++ b/src/Modules/Auth/Auth/Application/Public/UseCases/Commands/SetPassword/PublicSetPasswordCommand.cs
@@ -1,0 +1,22 @@
+using _116.Shared.Contracts.Application.CQRS;
+
+namespace _116.Auth.Application.Public.UseCases.Commands.SetPassword;
+
+/// <summary>
+/// Command for setting a password for a public user who authenticated via Google/Facebook.
+/// </summary>
+/// <param name="UserId">The unique identifier of the user setting their password.</param>
+/// <param name="Password">The password to set for the user.</param>
+/// <remarks>
+/// This command allows authenticated users who signed up via external providers to set a password.
+/// </remarks>
+public record PublicSetPasswordCommand(
+    Guid UserId,
+    string Password
+) : ICommand<PublicSetPasswordResult>;
+
+/// <summary>
+/// Result of the <see cref="PublicSetPasswordCommand"/> containing set status.
+/// </summary>
+/// <param name="IsSuccess">Indicates whether the password was set successfully.</param>
+public record PublicSetPasswordResult(bool IsSuccess);

--- a/src/Modules/Auth/Auth/Application/Public/UseCases/Commands/SetPassword/PublicSetPasswordHandler.cs
+++ b/src/Modules/Auth/Auth/Application/Public/UseCases/Commands/SetPassword/PublicSetPasswordHandler.cs
@@ -1,0 +1,50 @@
+using _116.Shared.Application.Exceptions;
+using _116.Auth.Application.Shared.Persistence;
+using _116.Shared.Contracts.Application.CQRS;
+using _116.Auth.Application.Shared.Repositories;
+using _116.Auth.Application.Shared.Services;
+using _116.Auth.Domain.Entities;
+
+namespace _116.Auth.Application.Public.UseCases.Commands.SetPassword;
+
+/// <summary>
+/// Handles the <see cref="PublicSetPasswordCommand"/> to set a password for external auth users (Google/Facebook).
+/// </summary>
+/// <param name="userRepository">Repository for user data access operations.</param>
+/// <param name="passwordService">Service for password hashing operations.</param>
+/// <param name="unitOfWork">Unit of Work for managing database transactions.</param>
+public class PublicSetPasswordHandler(
+    IUserRepository userRepository,
+    IPasswordService passwordService,
+    IAuthUnitOfWork unitOfWork
+) : ICommandHandler<PublicSetPasswordCommand, PublicSetPasswordResult>
+{
+    /// <summary>
+    /// Handles the password set command for external auth users.
+    /// </summary>
+    /// <param name="command">The password set command containing user ID and new password.</param>
+    /// <param name="cancellationToken">Token to cancel the operation.</param>
+    /// <returns>A <see cref="PublicSetPasswordResult"/> containing set status.</returns>
+    /// <exception cref="NotFoundException">Thrown when no user is found with the specified ID.</exception>
+    /// <exception cref="BadRequestException">Thrown when the account is not active.</exception>
+    /// <exception cref="BadRequestException">Thrown when the user doesn't have an email address.</exception>
+    /// <exception cref="BadRequestException">Thrown when user's auth provider is already Local.</exception>
+    public async Task<PublicSetPasswordResult> Handle(
+        PublicSetPasswordCommand command,
+        CancellationToken cancellationToken
+    )
+    {
+        UserEntity? user = await userRepository.FindUserByIdOrThrow(command.UserId, cancellationToken);
+
+        // Validate user account status - accounts must be active
+        userRepository.IsUserAccountActive(user!);
+
+        // Hash the new password
+        string hashedPassword = passwordService.Hash(command.Password);
+        userRepository.SetPasswordForExternalUser(user!, hashedPassword);
+
+        await unitOfWork.CommitAsync(cancellationToken);
+
+        return new PublicSetPasswordResult(IsSuccess: true);
+    }
+}

--- a/src/Modules/Auth/Auth/Application/Public/UseCases/Commands/SetPassword/PublicSetPasswordMetaField.cs
+++ b/src/Modules/Auth/Auth/Application/Public/UseCases/Commands/SetPassword/PublicSetPasswordMetaField.cs
@@ -1,0 +1,62 @@
+using _116.Shared.Application.Metadata;
+
+namespace _116.Auth.Application.Public.UseCases.Commands.SetPassword;
+
+/// <summary>
+/// Contains metadata information for the public user set password route.
+/// </summary>
+public static class PublicSetPasswordMetaField
+{
+    /// <summary>
+    /// Metadata describing the public user set password endpoint.
+    /// </summary>
+    public static readonly RouteMetadata SetPassword = new(
+        name: "PublicSetPassword",
+        summary: "Set password for external auth users (Google/Facebook)",
+        description: """
+             Allows users who authenticated via external providers (Google/Facebook) to set a password for local authentication.
+             \n
+             This endpoint performs the following operations:\n
+             - Validates JWT token authentication and extracts user ID\n
+             - Verifies user account is active\n
+             - Checks that user has an email address configured\n
+             - Validates that user's current auth provider is Google or Facebook (not Local)\n
+             - Hashes the new password using secure algorithms\n
+             - Sets the password and changes auth provider to Local\n
+             - Updates the user in the database\n
+             \n
+             **Request Requirements:**\n
+             - Valid password meeting security requirements\n
+             - User must be authenticated with valid JWT token\n
+             - User must have authenticated via Google or Facebook originally\n
+             - User must have an email address configured\n
+             \n
+             **Response Codes:**\n
+             - Returns 200 OK with success status\n
+             - Returns 400 Bad Request for missing email, already set password, or invalid auth provider\n
+             - Returns 401 Unauthorized for invalid/missing JWT token\n
+             - Returns 403 Forbidden for inactive accounts\n
+             - Returns 404 Not Found for user not found\n
+             \n
+             **Error Handling:**\n
+             - BadRequestException (400): Missing email, password already set, or not external auth user\n
+             - AuthenticationException (401): Invalid JWT token\n
+             - AuthorizationException (403): Account not active\n
+             - NotFoundException (404): User not found\n
+             \n
+             **Process Flow:**\n
+             1. Validates JWT token and extracts user ID\n
+             2. Validates password requirements\n
+             3. Finds user by ID and validates account status\n
+             4. Checks that user has an email address\n
+             5. Validates user's current auth provider is Google or Facebook\n
+             6. Hashes new password securely\n
+             7. Sets password and changes auth provider to Local\n
+             8. Updates user in database\n
+             9. Returns success response.\n
+             \n
+             **Note:** After successfully setting a password, users can log in using their email and password,\n
+             in addition to continuing to use their external authentication provider.
+         """
+    );
+}

--- a/src/Modules/Auth/Auth/Application/Public/UseCases/Commands/SetPassword/PublicSetPasswordValidator.cs
+++ b/src/Modules/Auth/Auth/Application/Public/UseCases/Commands/SetPassword/PublicSetPasswordValidator.cs
@@ -1,0 +1,23 @@
+using FluentValidation;
+using _116.Auth.Application.Shared.Validators;
+
+namespace _116.Auth.Application.Public.UseCases.Commands.SetPassword;
+
+/// <summary>
+/// Validator for the <see cref="PublicSetPasswordCommand"/> ensuring proper password format.
+/// </summary>
+/// <remarks>
+/// Validates password according to security requirements:
+/// - Password: Strong password with mixed cases, numbers, minimum length
+/// </remarks>
+public partial class PublicSetPasswordValidator : AbstractValidator<PublicSetPasswordCommand>
+{
+    /// <summary>
+    /// Configure validation rules for Public user password setting.
+    /// </summary>
+    public PublicSetPasswordValidator()
+    {
+        // Password validation - strong password requirements
+        RuleFor(x => x.Password).PasswordValidation(fieldName: "Password");
+    }
+}

--- a/src/Modules/Auth/Auth/Application/Public/UseCases/Commands/SetPassword/V1/PublicSetPasswordEndpointV1.cs
+++ b/src/Modules/Auth/Auth/Application/Public/UseCases/Commands/SetPassword/V1/PublicSetPasswordEndpointV1.cs
@@ -1,0 +1,76 @@
+using _116.Shared.Contracts.Application.CQRS;
+using _116.Auth.Application.Shared.Repositories;
+using _116.Auth.Application.Shared.Constants;
+using _116.Auth.Domain.Constants;
+using _116.Shared.Application.Extensions;
+using Carter;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing;
+using System.Security.Claims;
+using _116.Auth.Application.Shared.Authorizations.Policies;
+
+namespace _116.Auth.Application.Public.UseCases.Commands.SetPassword.V1;
+
+/// <summary>
+/// Request model for the public user to set password.
+/// </summary>
+/// <param name="Password">The password to set for the user.</param>
+public record PublicSetPasswordRequest(string Password);
+
+/// <summary>
+/// Response model for the public user to set password.
+/// </summary>
+/// <param name="IsSuccess">Indicates whether the password was set successfully.</param>
+public record PublicSetPasswordResponse(bool IsSuccess);
+
+/// <summary>
+/// Defines the password set endpoint for authenticated users who used external authentication.
+/// Handles password setting for Google/Facebook users to enable local authentication.
+/// </summary>
+public class PublicSetPasswordEndpointV1 : ICarterModule
+{
+    /// <summary>
+    /// Configures the public password set route within the API pipeline.
+    /// Maps the <c>/api/v1/public/auth/set-password</c> endpoint to handle password set requests.
+    /// </summary>
+    /// <param name="app">The route builder used to register API endpoints.</param>
+    public void AddRoutes(IEndpointRouteBuilder app)
+    {
+        RouteGroupBuilder group = app
+            .MapApiVersionGroup(version: 1)
+            .MapGroup($"{AuthConstants.Public}/{AuthRouteConstants.Endpoint}")
+            .WithTags($"{AuthConstants.Public}::{AuthConstants.SchemaName}");
+
+        group.MapPost(AuthRouteConstants.SetPassword, async (
+                PublicSetPasswordRequest request,
+                ClaimsPrincipal user,
+                IUserRepository userRepository,
+                IDispatcher dispatcher
+            ) =>
+            {
+                // Extract user ID from JWT token claims
+                Guid userId = userRepository.GetUserIdFromClaims(user);
+
+                // Send the command to set the password
+                var command = new PublicSetPasswordCommand(userId, request.Password);
+
+                PublicSetPasswordResult result = await dispatcher.Send(command);
+
+                // Adapt the result to the response type
+                var response = new PublicSetPasswordResponse(result.IsSuccess);
+
+                return Results.Ok(response);
+            })
+            .WithName(PublicSetPasswordMetaField.SetPassword.Name)
+            .WithSummary(PublicSetPasswordMetaField.SetPassword.Summary)
+            .WithDescription(PublicSetPasswordMetaField.SetPassword.Description)
+            .RequireAuthorization(UserRolePolicies.RequireVisitorOnly)
+            .ProducesValidationProblem()
+            .Produces<PublicSetPasswordResponse>()
+            .ProducesProblem(StatusCodes.Status400BadRequest)
+            .ProducesProblem(StatusCodes.Status401Unauthorized)
+            .ProducesProblem(StatusCodes.Status403Forbidden)
+            .ProducesProblem(StatusCodes.Status404NotFound);
+    }
+}

--- a/src/Modules/Auth/Auth/Application/Shared/Constants/AuthRouteConstants.cs
+++ b/src/Modules/Auth/Auth/Application/Shared/Constants/AuthRouteConstants.cs
@@ -29,6 +29,13 @@ public static class AuthRouteConstants
     public const string ChangePassword = "change-password";
 
     /// <summary>
+    /// Route segment for password set endpoints.
+    /// Used when external auth users (Google/Facebook) want to set their initial password.
+    /// Example: /api/v1/admin/auth/set-password.
+    /// </summary>
+    public const string SetPassword = "set-password";
+
+    /// <summary>
     /// Route segment for password recovery initiation endpoints.
     /// Used when users request a password reset via email.
     /// Example: /api/v1/public/auth/forgot-password.

--- a/src/Modules/Auth/Auth/Application/Shared/Errors/Messages/ValidationErrorMessage.cs
+++ b/src/Modules/Auth/Auth/Application/Shared/Errors/Messages/ValidationErrorMessage.cs
@@ -158,4 +158,26 @@ public static class ValidationErrorMessage
     {
         return "The current password you entered is incorrect.";
     }
+
+    /// <summary>
+    /// Error message indicating that an email address is required to set a password.
+    /// </summary>
+    /// <returns>
+    /// An error message indicating that the user must have an email address before setting a password.
+    /// </returns>
+    public static string EmailRequiredToSetPassword()
+    {
+        return "An email address is required to set a password";
+    }
+
+    /// <summary>
+    /// Error message indicating that setting password is only allowed for external auth users.
+    /// </summary>
+    /// <returns>
+    /// An error message indicating that only Google or Facebook users can set a password.
+    /// </returns>
+    public static string PasswordOnlyForExternalAuth()
+    {
+        return "Setting password is only allowed for Google or Facebook users.";
+    }
 }

--- a/src/Modules/Auth/Auth/Application/Shared/Errors/UserErrors.cs
+++ b/src/Modules/Auth/Auth/Application/Shared/Errors/UserErrors.cs
@@ -205,4 +205,16 @@ public static class UserErrors
     /// </summary>
     public static BadRequestException IncorrectCurrentPassword() =>
         new(ValidationErrorMessage.IncorrectCurrentPassword());
+
+    /// <summary>
+    /// Throws when an email address is required to set a password.
+    /// </summary>
+    public static BadRequestException EmailRequiredToSetPassword() =>
+        new(ValidationErrorMessage.EmailRequiredToSetPassword());
+
+    /// <summary>
+    /// Throws when setting password is only allowed for external auth users (Google/Facebook).
+    /// </summary>
+    public static BadRequestException PasswordOnlyForExternalAuth() =>
+        new(ValidationErrorMessage.PasswordOnlyForExternalAuth());
 }

--- a/src/Modules/Auth/Auth/Application/Shared/Repositories/IUserRepository.cs
+++ b/src/Modules/Auth/Auth/Application/Shared/Repositories/IUserRepository.cs
@@ -290,4 +290,21 @@ public interface IUserRepository : IRepository<UserEntity>
         AuthProvider authProvider,
         CancellationToken cancellationToken = default
     );
+
+    /// <summary>
+    /// Sets a password for an external authentication user and changes their auth provider to Local.
+    /// </summary>
+    /// <param name="user">The user entity to set password for.</param>
+    /// <param name="hashedPassword">The hashed password to set.</param>
+    /// <exception cref="BadRequestException">Thrown when user already has Local auth provider.</exception>
+    /// <exception cref="BadRequestException">Thrown when user auth provider is not Google or Facebook.</exception>
+    /// <exception cref="BadRequestException">Thrown when user doesn't have an email address.</exception>
+    /// <remarks>
+    /// This method validates that:
+    /// - User doesn't already have Local auth (password not already set)
+    /// - User's auth provider is Google or Facebook
+    /// - User has an email address configured
+    /// Upon success, sets the password hash and changes auth provider to Local.
+    /// </remarks>
+    void SetPasswordForExternalUser(UserEntity user, string hashedPassword);
 }

--- a/src/Modules/Auth/Auth/Domain/Entities/UserEntity.cs
+++ b/src/Modules/Auth/Auth/Domain/Entities/UserEntity.cs
@@ -234,6 +234,32 @@ public class UserEntity : Aggregate<Guid>
     }
 
     /// <summary>
+    /// Sets the user's password and changes the authentication provider to Local.
+    /// </summary>
+    /// <param name="passwordHash">The hashed password to set.</param>
+    /// <exception cref="ArgumentNullException">Thrown when password hash is null or empty.</exception>
+    /// <exception cref="BadRequestException">Thrown when user doesn't have an email address.</exception>
+    /// <remarks>
+    /// This method is used when external authentication users (Google/Facebook) set their password for the first time.
+    /// It updates both the password hash and changes the auth provider to Local to enable password-based login.
+    /// </remarks>
+    public void SetPasswordAndChangeToLocal(string passwordHash)
+    {
+        if (string.IsNullOrWhiteSpace(passwordHash))
+        {
+            throw UserErrors.InvalidPasswordFormat();
+        }
+
+        if (string.IsNullOrEmpty(Email))
+        {
+            throw UserErrors.EmailRequiredToSetPassword();
+        }
+
+        PasswordHash = passwordHash;
+        AuthProvider = EnumAuthProvider.Local;
+    }
+
+    /// <summary>
     /// Updates the user's username.
     /// </summary>
     /// <param name="newUserName">The new username.</param>

--- a/src/Modules/Auth/Auth/Infrastructure/Repositories/UserRepository.cs
+++ b/src/Modules/Auth/Auth/Infrastructure/Repositories/UserRepository.cs
@@ -326,4 +326,22 @@ public class UserRepository(AuthDbContext context) : IUserRepository
 
         return user;
     }
+
+    /// <inheritdoc />
+    public void SetPasswordForExternalUser(UserEntity user, string hashedPassword)
+    {
+        // Check if user has an email address
+        if (string.IsNullOrEmpty(user.Email))
+        {
+            throw UserErrors.EmailRequiredToSetPassword();
+        }
+
+        // Check if user already has a password set
+        if (user.AuthProvider == EnumAuthProvider.Local)
+        {
+            throw UserErrors.PasswordOnlyForExternalAuth();
+        }
+
+        user.SetPasswordAndChangeToLocal(hashedPassword);
+    }
 }


### PR DESCRIPTION
- [x] [feat: implement set password endpoint](https://github.com/coolbeatz71/116-backend/commit/7b38163530efe6230d565057b4a302279e13a6a1)
- [x] [feat: implement set password validation](https://github.com/coolbeatz71/116-backend/commit/9ba0ac0f6c9a1c64856d7e4eaa770d9b87bb2add)
- [x] [feat: create entity method to set password and change auth to Local](https://github.com/coolbeatz71/116-backend/commit/b2069e4e55fc791abd307a88f2d676fc5285a8cc)
- [x] [feat: create the set password metadata documentation](https://github.com/coolbeatz71/116-backend/commit/ad6fdcd66a731c47125607bd6e4fca636922478b)
- [x] [feat: add SetPasswordForExternalUser to the IUserRepository](https://github.com/coolbeatz71/116-backend/pull/41/commits/961ae450a873319c0af88001b92fcb50b28dc1ad)
- [x]  [feat: implement the set password handler](https://github.com/coolbeatz71/116-backend/pull/41/commits/8c9517e17588c16a03c683c6802e7fb5fee4918d)